### PR TITLE
Match .jsx anywhere in the filename

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,6 +4,7 @@ module.exports = class ReactCompiler
   brunchPlugin: yes
   type: 'javascript'
   extension: 'jsx'
+  pattern: /\.jsx/
 
   constructor: (@config) ->
     @includeHeader= @config?.plugins?.react?.autoIncludeCommentBlock is yes


### PR DESCRIPTION
Might it be helpful to match files that have `.jsx` anywhere in their filename?

I myself have a build system that parses Coffeescript, then JSX. I name my files `foo.jsx.coffee`.

Without this patch, I have to do the following in `brunch-config.coffee` (which might be good enough):

```
ReactCompiler = require 'react-brunch'
ReactCompiler::pattern = /\.jsx/
```

Thoughts?
