### PR TITLE
Changing react-tools version to strictly 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "node_modules/.bin/mocha --require test/common.js"
   },
   "dependencies": {
-    "react-tools": ">=0.12.1",
+    "react-tools": "0.12.1",
     "jstransform": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
react-tools 0.13 breaks react-brunch (html tags are not reactified)